### PR TITLE
Added .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ nb-configuration.xml
 #.war
 *.ear
 
+# Gross Mac Files
+.DS_Store


### PR DESCRIPTION
This is a OSX artifact that isn't necessary in the repo.
